### PR TITLE
[4월 3주차] 가장 긴 바이토닉 부분 수열

### DIFF
--- a/src/Beakjoon/BOJ_11054_가장긴바이토닉부분수열_박재환.java
+++ b/src/Beakjoon/BOJ_11054_가장긴바이토닉부분수열_박재환.java
@@ -1,0 +1,100 @@
+package Beakjoon;
+
+import java.util.*;
+import java.io.*;
+
+public class BOJ_11054_가장긴바이토닉부분수열_박재환 {
+    static BufferedReader br;
+    public static void main(String[] args) throws IOException {
+        br = new BufferedReader(new InputStreamReader(System.in));
+        init();
+        br.close();
+    }
+
+    static StringTokenizer st;
+    static int arrLen;      // 수열의 길이
+    static int[] inputArr;  // 입력된 수열
+    static void init() throws IOException {
+        arrLen = Integer.parseInt(br.readLine().trim());
+        inputArr = new int[arrLen];
+
+        st = new StringTokenizer(br.readLine().trim());
+        for(int idx=0; idx<arrLen; idx++) {
+            inputArr[idx] = Integer.parseInt(st.nextToken());
+        }
+
+        getLIS();
+    }
+
+    /*
+        정방향으로 LIS 를 구한다.
+        역방향으로 LIS 를 구한다.
+
+        중간치가 최대인 값을 구한다.
+     */
+    static int[] lisArr, reLisArr;      // 정방향, 역방향
+    static void getLIS() {
+        lisArr = new int[arrLen];
+        reLisArr = new int[arrLen];
+
+        // 1. 정방향으로 증가하는 부분 수열을 구한다.
+        List<Integer> list = new ArrayList<>();
+        list.add(inputArr[0]);
+        lisArr[0] = 1;
+        for(int idx=1; idx<arrLen; idx++) {
+            if(list.get(list.size()-1) < inputArr[idx]) {   // 현재 마지막 원소보다 큰 수일 경우
+                list.add(inputArr[idx]);
+                lisArr[idx] = list.size();
+            } else {
+                int insertIdx = binarySearch(list, inputArr[idx]);
+                list.set(insertIdx, inputArr[idx]);
+                lisArr[idx] = insertIdx+1;  // ⚠️ list 는 전체 lis 의 최대 길이 -> num 을 끝으로 같는 lis의 길이가 아님
+            }
+        }
+
+        // 2. 역방향으로 증가하는 부분 수열을 구한다.
+        list = new ArrayList<>();
+        list.add(inputArr[arrLen-1]);
+        reLisArr[arrLen-1] = 1;
+        for(int idx=arrLen-2; idx>-1; idx--) {
+            if(list.get(list.size()-1) < inputArr[idx]) {   // 현재 마지막 원소보다 큰 수일 경우
+                list.add(inputArr[idx]);
+                reLisArr[idx] = list.size();
+            } else {
+                int insertIdx = binarySearch(list, inputArr[idx]);
+                list.set(insertIdx, inputArr[idx]);
+                reLisArr[idx] = insertIdx+1;  // ⚠️ list 는 전체 lis 의 최대 길이 -> num 을 끝으로 같는 lis의 길이가 아님
+            }
+        }
+
+//        System.out.println(Arrays.toString(lisArr));
+//        System.out.println(Arrays.toString(reLisArr));
+
+        int max = Integer.MIN_VALUE;
+        for(int idx=0; idx<arrLen; idx++) {
+            max = Math.max(max, lisArr[idx] + reLisArr[idx]);
+        }
+
+        // 중복되는 중간 값을 제거한다.
+        System.out.println(max-1);
+    }
+
+    /*
+        num 이상인 가장 작은 수를 반환한다.
+     */
+    static int binarySearch(List<Integer> list, int target) {
+        int l = 0, r = list.size()-1;
+
+        while(l < r) {
+            int mid = l + (r-l)/2;
+
+            if(list.get(mid) < target) {    // 찾으려는 수보다 작다면
+                l = mid+1;
+            } else {
+                r = mid;
+            }
+        }
+
+        return l;
+    }
+}


### PR DESCRIPTION
## 📝 문제 정보
[//]: # (PR 올리는 문제 이름과 문제 링크를 작성해주세요.)
- **문제 이름**: 가장 긴 바이토닉 부분 수
- **문제 링크**: https://www.acmicpc.net/problem/11054

## ✅  풀이 진행 상태
[//]: # (풀이 완료 후에는 채점된 실행시간과 메모리를 공유해주세요!)
- [x] 풀이 완료
- [ ] 풀이 진행 중 
![image](https://github.com/user-attachments/assets/239b1049-056e-470f-8da4-8d1a04a0f692)
## 💡  내 풀이 간단 설명
<!-- 자유 양식으로 간단히 풀이 과정을 공유해주세요. 아래는 기본 예시입니다.
- 큰 동전부터 차례대로 나누어 풀이 (그리디 알고리즘 적용)
- DP 접근법도 고려했지만, 최적해를 보장할 수 있다고 판단하여 그리디로 해결함
-->
LIS 를 활용하여 양방향 DP 를 사용해 해결할 수 있는 문제였습니다. 
연수님이 설명해주신 LIS 를 이분탐색으로 구현해보았습니다. 다만 한 가지 주의해야할 부분은 list 는 말 그대로, 현재 최대 LIS 의 길이이므로, 실제 현재 타겟 수가 마지막에 위치하는 LIS 의 수열의 길이가 아니므로, 이때는 현재 타겟 수가 들어갈 인덱스 값에 + 1 더해주었습니다. 

그리고, 교차되는 값을 비교할 때, 해당 위치의 값이 중복으로 들어가므로 1 제거해주었습니다.

## 💬 자유 의견 
<!-- 자유롭게 의견을 남겨도 좋고 빈칸으로 진행해도 좋아요! 
아래는 예시입니다.
- 더 좋은 변수명 추천 가능할까요?
- 시간 복잡도를 고려했을 때 개선할 부분이 있을까요?
- 이번 문제같은 경우에는 너무 어렵던데 이런 문제는 2일에 걸쳐 풀고 싶어요.
-->
이분 탐색을 이용해서 푸는법을 알게되어 뿌듯합니다 ( 연수형 고마워요ㅎㅅㅎ )