### PR TITLE
[4월 3주차] 점프 - 박재환

### DIFF
--- a/src/Beakjoon/BOJ_1890_점프_박재환.java
+++ b/src/Beakjoon/BOJ_1890_점프_박재환.java
@@ -1,0 +1,68 @@
+package Beakjoon;
+
+import java.util.*;
+import java.io.*;
+
+public class BOJ_1890_점프_박재환 {
+    static BufferedReader br;
+    public static void main(String[] args) throws IOException {
+        br = new BufferedReader(new InputStreamReader(System.in));
+        init();
+        br.close();
+    }
+
+    static StringTokenizer st;
+    static int mapSize;
+    static int[][] map;
+    static void init() throws IOException {
+        mapSize = Integer.parseInt(br.readLine().trim());
+        map = new int[mapSize][mapSize];
+
+        for(int x=0; x<mapSize; x++) {
+            st = new StringTokenizer(br.readLine().trim());
+            for(int y=0; y<mapSize; y++) {
+                map[x][y] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        // 입력 확인
+//        for(int[] arr : map) {
+//            System.out.println(Arrays.toString(arr));
+//        }
+//        System.out.println();
+        findAllRoute();
+    }
+
+    /*
+        탐색 방향이 오른쪽, 아래쪽으로 탐색한다.
+        각 칸에 적힌 수 만큼 점프를 할 수 있다.
+        좌측과 상단에 마진을 두고 DP 를 탐색한다.
+     */
+    static void findAllRoute() {
+        long[][] dpArr = new long[mapSize][mapSize];
+        dpArr[0][0] = 1;
+        for(int x=0; x<mapSize; x++) {
+            for(int y=0; y<mapSize; y++) {
+                int jump = map[x][y];
+
+                // 점프를 할 수 없다면 해당 경로는 제외한다.
+                if(map[x][y] == 0) continue;
+                
+                // 점프를 할 수 있는지
+                if (x + jump < mapSize) {
+                    dpArr[x + jump][y] += dpArr[x][y];
+                }
+                if (y + jump < mapSize) {
+                    dpArr[x][y + jump] += dpArr[x][y];
+                }
+            }
+        }
+
+//        for(int[] arr : dpArr) {
+//            System.out.println(Arrays.toString(arr));
+//        }
+//        System.out.println();
+
+        System.out.println(dpArr[mapSize-1][mapSize-1]);
+    }
+}


### PR DESCRIPTION
## 📝 문제 정보
[//]: # (PR 올리는 문제 이름과 문제 링크를 작성해주세요.)
- **문제 이름**: 점 
- **문제 링크**: https://www.acmicpc.net/problem/1890

## ✅  풀이 진행 상태
[//]: # (풀이 완료 후에는 채점된 실행시간과 메모리를 공유해주세요!)
- [x] 풀이 완료
- [ ] 풀이 진행 중 
![image](https://github.com/user-attachments/assets/5446fe6d-df34-44c2-97de-00f6a1ab90e9)

## 💡  내 풀이 간단 설명
<!-- 자유 양식으로 간단히 풀이 과정을 공유해주세요. 아래는 기본 예시입니다.
- 큰 동전부터 차례대로 나누어 풀이 (그리디 알고리즘 적용)
- DP 접근법도 고려했지만, 최적해를 보장할 수 있다고 판단하여 그리디로 해결함
-->
DP 로 풀었습니다. 각 칸에서 이동할 수 있는 칸으로 바로 점프 시켜가며 경로를 누적했습니다. 

경로의 개수가 최대 2^63-1 개 이므로 DP 배열을 long 으로 하지 않으면 80% 에서 틀리네요..

## 💬 자유 의견 
<!-- 자유롭게 의견을 남겨도 좋고 빈칸으로 진행해도 좋아요! 
아래는 예시입니다.
- 더 좋은 변수명 추천 가능할까요?
- 시간 복잡도를 고려했을 때 개선할 부분이 있을까요?
- 이번 문제같은 경우에는 너무 어렵던데 이런 문제는 2일에 걸쳐 풀고 싶어요.
-->
다시 long 을 사용하는 습관을..